### PR TITLE
Fix for #1, correct WyRng state mutation

### DIFF
--- a/src/WyHash/WyRng.cs
+++ b/src/WyHash/WyRng.cs
@@ -11,7 +11,7 @@ namespace WyHash
     public class WyRng
     {
         private ulong seed;
-        
+
         /// <summary>
         /// Initializes a new instance with the specified seed value
         /// </summary>
@@ -20,7 +20,7 @@ namespace WyHash
         {
             this.seed = seed;
         }
-        
+
         /// <summary>
         /// Returns a non-negative, random 64-bit integer
         /// </summary>
@@ -28,11 +28,11 @@ namespace WyHash
         public ulong NextLong()
         {
             this.seed += WyCore.Prime0;
-            this.seed = WyCore.Mum(this.seed ^ WyCore.Prime1, this.seed);
+            var result = WyCore.Mum(this.seed ^ WyCore.Prime1, this.seed);
 
-            return seed;
+            return result;
         }
-        
+
         /// <summary>
         /// Returns a non-negative, random integer
         /// </summary>
@@ -42,7 +42,7 @@ namespace WyHash
             var next = NextLong();
             return (int)next;
         }
-        
+
         /// <summary>
         /// Fills the elements of a specified array of bytes with random bytes
         /// </summary>
@@ -50,12 +50,12 @@ namespace WyHash
         /// <exception cref="ArgumentNullException"></exception>
         public void NextBytes(byte[] buffer)
         {
-            if (buffer == null) 
+            if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
 
             // Determine how many 64-bit integers we need to generate to fill the buffer
             var numVals = Math.Ceiling((double)buffer.Length / 8);
-            
+
             // Fill the buffer with 8 bytes (1 ulong) at a time (WriteBytes will ensure we correctly handle any
             // remaining bytes)
             for (int i = 0; i < numVals; i++)
@@ -64,7 +64,7 @@ namespace WyHash
                 WriteBytes(next, buffer, i * 8);
             }
         }
-        
+
         /// <summary>
         /// Fills the elements of a specified array of bytes with random bytes
         /// </summary>
@@ -72,12 +72,12 @@ namespace WyHash
         /// <exception cref="ArgumentNullException"></exception>
         public void NextBytes(Span<byte> buffer)
         {
-            if (buffer == null) 
+            if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
-            
+
             // Determine how many 64-bit integers we need to generate to fill the buffer
             var numVals = Math.Ceiling((double)buffer.Length / 8);
-            
+
             // Fill the buffer with 8 bytes (1 ulong) at a time (WriteBytes will ensure we correctly handle any
             // remaining bytes)
             for (int i = 0; i < numVals; i++)
@@ -85,13 +85,13 @@ namespace WyHash
                 var next = NextLong();
                 WriteBytes(next, buffer, i * 8);
             }
-            
+
             for (int i = 0; i < buffer.Length; i++)
             {
                 buffer[i] = (byte)NextLong();
             }
         }
-        
+
         /// <summary>
         /// Writes an unsigned 64-bit integer to an existing byte array
         /// </summary>
@@ -102,7 +102,7 @@ namespace WyHash
         private static void WriteBytes(ulong value, Span<byte> array, int offset)
         {
             var max = Math.Min(8, array.Length - offset);
-            
+
             for (int i = 0; i < max; i++)
             {
                 array[offset + i] = (byte)value;


### PR DESCRIPTION
Don't mutate state with MUM operation when generating random numbers